### PR TITLE
Add `bin/codeownership for_file` CLI to power extension

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    code_ownership (1.23.0)
+    code_ownership (1.24.0)
       bigrails-teams
       parse_packwerk
       sorbet-runtime
@@ -10,7 +10,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    bigrails-teams (0.1.0)
+    bigrails-teams (0.1.1)
       sorbet-runtime
     coderay (1.1.3)
     diff-lcs (1.4.4)

--- a/code_ownership.gemspec
+++ b/code_ownership.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "code_ownership"
-  spec.version       = '1.23.0'
+  spec.version       = '1.24.0'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'A gem to help engineering teams declare ownership of code'

--- a/lib/code_ownership/cli.rb
+++ b/lib/code_ownership/cli.rb
@@ -6,11 +6,11 @@ require 'pathname'
 module CodeOwnership
   class Cli
     def self.run!(argv)
-      # Someday we might support other subcommands. When we do that, we can call
-      # argv.shift to get the first argument and check if it's a given subcommand.
       command = argv.shift
       if command == 'validate'
         validate!(argv)
+      elsif command == 'for_file'
+        for_file(argv)
       end
     end
 
@@ -53,6 +53,55 @@ module CodeOwnership
         autocorrect: !options[:skip_autocorrect],
         stage_changes: !options[:skip_stage]
       )
+    end
+
+    # For now, this just returns team ownership
+    # Later, this could also return code ownership errors about that file.
+    def self.for_file(argv)
+      options = {}
+
+      # Long-term, we probably want to use something like `thor` so we don't have to implement logic
+      # like this. In the short-term, this is a simple way for us to use the built-in OptionParser
+      # while having an ergonomic CLI.
+      files = argv.select { |arg| !arg.start_with?('--') }
+
+      parser = OptionParser.new do |opts|
+        opts.banner = 'Usage: bin/codeownership for_file [options]'
+
+        opts.on('--json', 'Output as JSON') do
+          options[:json] = true
+        end
+
+        opts.on('--help', 'Shows this prompt') do
+          puts opts
+          exit
+        end
+      end
+      args = parser.order!(argv) {}
+      parser.parse!(args)
+
+      if files.count != 1
+        raise "Please pass in one file. Use `bin/codeownership for_file --help` for more info"
+      end
+      
+      team = CodeOwnership.for_file(files.first)
+
+      team_name = team&.name || "Unowned"
+      team_yml = team&.config_yml || "Unowned"
+
+      if options[:json]
+        json = {
+          team_name: team_name,
+          team_yml: team_yml,
+        }
+
+        puts json.to_json
+      else
+        puts <<~MSG
+          Team: #{team_name}
+          Team YML: #{team_yml}
+        MSG
+      end
     end
 
     private_class_method :validate!

--- a/sorbet/rbi/manual.rbi
+++ b/sorbet/rbi/manual.rbi
@@ -1,0 +1,3 @@
+class Hash
+  def to_json; end
+end

--- a/spec/lib/code_ownership/cli_spec.rb
+++ b/spec/lib/code_ownership/cli_spec.rb
@@ -26,4 +26,29 @@ RSpec.describe CodeOwnership::Cli do
     end
 
   end
+
+  describe 'for_file' do
+    before do
+      write_file('config/code_ownership.yml', <<~YML)
+        owned_globs:
+          - 'app/**/*.rb'
+      YML
+
+      write_file('app/services/my_file.rb')
+    end
+
+    # context 'when run with no flags' do
+    #   context 'when run with one file' do
+        
+    #   end
+    # end
+
+    context 'when run with --json' do
+      let(:argv) { ['for_file', '--json', 'app/services/my_file.rb'] }
+
+      context 'when run with one file' do
+        it 'outputs JSONified information to the console'
+      end
+    end
+  end
 end

--- a/spec/lib/code_ownership/cli_spec.rb
+++ b/spec/lib/code_ownership/cli_spec.rb
@@ -1,26 +1,29 @@
 RSpec.describe CodeOwnership::Cli do
   subject { CodeOwnership::Cli.run!(argv) }
 
-  let(:argv) { ['validate'] }
+  describe 'validate' do
+    let(:argv) { ['validate'] }
 
-  before do
-    write_file('config/code_ownership.yml', <<~YML)
-      owned_globs:
-        - 'app/**/*.rb'
-    YML
+    before do
+      write_file('config/code_ownership.yml', <<~YML)
+        owned_globs:
+          - 'app/**/*.rb'
+      YML
 
-    write_file('app/services/my_file.rb')
-    write_file('frontend/javascripts/my_file.jsx')
-  end
-
-  context 'when run without arguments' do
-    it 'runs validations with the right defaults' do
-      expect(CodeOwnership).to receive(:validate!) do |args| # rubocop:disable RSpec/MessageSpies
-        expect(args[:autocorrect]).to eq true
-        expect(args[:stage_changes]).to eq true
-        expect(args[:files]).to match_array(['app/services/my_file.rb'])
-      end
-      subject
+      write_file('app/services/my_file.rb')
+      write_file('frontend/javascripts/my_file.jsx')
     end
+
+    context 'when run without arguments' do
+      it 'runs validations with the right defaults' do
+        expect(CodeOwnership).to receive(:validate!) do |args| # rubocop:disable RSpec/MessageSpies
+          expect(args[:autocorrect]).to eq true
+          expect(args[:stage_changes]).to eq true
+          expect(args[:files]).to match_array(['app/services/my_file.rb'])
+        end
+        subject
+      end
+    end
+
   end
 end

--- a/spec/lib/code_ownership/cli_spec.rb
+++ b/spec/lib/code_ownership/cli_spec.rb
@@ -35,19 +35,71 @@ RSpec.describe CodeOwnership::Cli do
       YML
 
       write_file('app/services/my_file.rb')
+      write_file('config/teams/my_team.yml', <<~YML)
+        name: My Team
+        owned_globs: 
+          - 'app/**/*.rb'
+      YML
     end
 
-    # context 'when run with no flags' do
-    #   context 'when run with one file' do
+    context 'when run with no flags' do
+      context 'when run with one file' do
+        let(:argv) { ['for_file', 'app/services/my_file.rb'] }
         
-    #   end
-    # end
+        it 'outputs the team info in human readable format' do
+          expect(CodeOwnership::Cli).to receive(:puts).with(<<~MSG)
+            Team: My Team
+            Team YML: config/teams/my_team.yml
+          MSG
+          subject
+        end
+      end
+
+      context 'when run with no files' do
+        let(:argv) { ['for_file'] }
+        
+        it 'outputs the team info in human readable format' do
+          expect { subject }.to raise_error "Please pass in one file. Use `bin/codeownership for_file --help` for more info"
+        end
+      end
+
+      context 'when run with multiple files' do
+        let(:argv) { ['for_file', 'app/services/my_file.rb', 'app/services/my_file2.rb'] }
+        
+        it 'outputs the team info in human readable format' do
+          expect { subject }.to raise_error "Please pass in one file. Use `bin/codeownership for_file --help` for more info"
+        end
+      end
+    end
 
     context 'when run with --json' do
       let(:argv) { ['for_file', '--json', 'app/services/my_file.rb'] }
 
       context 'when run with one file' do
-        it 'outputs JSONified information to the console'
+        it 'outputs JSONified information to the console' do
+          json = {
+            team_name: 'My Team',
+            team_yml: 'config/teams/my_team.yml'
+          }
+          expect(CodeOwnership::Cli).to receive(:puts).with(json.to_json)
+          subject
+        end
+      end
+
+      context 'when run with no files' do
+        let(:argv) { ['for_file', '--json'] }
+        
+        it 'outputs the team info in human readable format' do
+          expect { subject }.to raise_error "Please pass in one file. Use `bin/codeownership for_file --help` for more info"
+        end
+      end
+
+      context 'when run with multiple files' do
+        let(:argv) { ['for_file', 'app/services/my_file.rb', 'app/services/my_file2.rb'] }
+        
+        it 'outputs the team info in human readable format' do
+          expect { subject }.to raise_error "Please pass in one file. Use `bin/codeownership for_file --help` for more info"
+        end
       end
     end
   end


### PR DESCRIPTION
# Summary
The goal of this is to power a VSCode Extension to show ownership of a file.

# Example Usage
```
~/workspace/zenpayroll - (ae-experiment-with-code-ownership-cli) $ bin/codeownership for_file packs/feature_flags/app/services/features/enabled.rb 
Team: Product Infrastructure
Team YML: config/teams/foundation/product_infrastructure.yml
~/workspace/zenpayroll - (ae-experiment-with-code-ownership-cli) $ bin/codeownership for_file packs/feature_flags/app/services/features/enabled.rb --json
{"team_name":"Product Infrastructure","team_yml":"config/teams/foundation/product_infrastructure.yml"}
```

# What to Focus On
I'd love reviewers to let me know if this is a good public API for this extension, keeping in mind questions like:
- Will this let me add an `errors` key that will allow the extension to also show code ownership errors for the file
- Will this API support other possible future extensions for the extension
  - Other things we talked about were allowing the extension to *add ownership* for a file with a given strategy
- Is this a good format for the output (both human and JSON)
- Does this general API seem alright?