### PR TITLE
Improve CLI UX by more providing feedback when an unrecognized command is used

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    code_ownership (1.25.0)
+    code_ownership (1.26.0)
       bigrails-teams
       parse_packwerk
       sorbet-runtime

--- a/code_ownership.gemspec
+++ b/code_ownership.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "code_ownership"
-  spec.version       = '1.25.0'
+  spec.version       = '1.26.0'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'A gem to help engineering teams declare ownership of code'

--- a/lib/code_ownership/cli.rb
+++ b/lib/code_ownership/cli.rb
@@ -11,7 +11,19 @@ module CodeOwnership
         validate!(argv)
       elsif command == 'for_file'
         for_file(argv)
+      elsif [nil, "help"].include?(command)
+        puts <<~USAGE
+          Usage: bin/codeownership <subcommand>
+
+          Subcommands:
+            validate - run all validations
+            for_file - find code ownership for a single file
+            help  - display help information about code_ownership
+        USAGE
+      else
+        puts "'#{command}' is not a code_ownership command. See `bin/codeownership help`."
       end
+
     end
 
     def self.validate!(argv)

--- a/spec/lib/code_ownership/cli_spec.rb
+++ b/spec/lib/code_ownership/cli_spec.rb
@@ -103,4 +103,30 @@ RSpec.describe CodeOwnership::Cli do
       end
     end
   end
+
+  describe 'using unknown command' do
+    let(:argv) { ['some_command'] }
+
+    it 'outputs help text' do
+      expect(CodeOwnership::Cli).to receive(:puts).with("'some_command' is not a code_ownership command. See `bin/codeownership help`.")
+      subject
+    end
+  end
+
+  describe 'passing in no command' do
+    let(:argv) { [] }
+
+    it 'outputs help text' do
+      expected = <<~EXPECTED
+      Usage: bin/codeownership <subcommand>
+
+      Subcommands:
+        validate - run all validations
+        for_file - find code ownership for a single file
+        help  - display help information about code_ownership
+      EXPECTED
+      expect(CodeOwnership::Cli).to receive(:puts).with(expected)
+      subject
+    end
+  end
 end


### PR DESCRIPTION
Some users have been confused when `bin/codeownership` doesn't produce the output they expect. This PR attempts to make this clearer by providing a help menu when no command is entered and an error message if an unrecognized command is outputted.